### PR TITLE
Tweaked benchmark parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ ifeq ($(DEBUG),1)
 GENFLAGS = -fPIC  -ggdb  -march=native -Wall -Wextra -pedantic -Wshadow -fsanitize=undefined  -fno-omit-frame-pointer -fsanitize=address -Wno-unused
 else
 GENFLAGS =  -fPIC -O3  -march=native -Wall -Wextra -pedantic -Wshadow -Wno-unused
+#GENFLAGS =  -fPIC -O3 -mavx2 -Wall -Wextra -pedantic -Wshadow -Wno-unused
+#GENFLAGS =  -fPIC -O3 -msse2 -Wall -Wextra -pedantic -Wshadow -Wno-unused
 endif # debug
 CFLAGS =  -std=c99 $(GENFLAGS)
 CXXFLAGS = -std=c++11 -fpermissive $(GENFLAGS)

--- a/benchmarks/decodebenchmark.cpp
+++ b/benchmarks/decodebenchmark.cpp
@@ -2,21 +2,51 @@
 #include <cassert>
 #include <iostream>
 
+#include <stdlib.h>
+
 #include "benchmark.h"
+
+#ifdef __AVX2__
 #include "avxcodec.h"
+#endif
+
 #include "scalar.h"
 
 
-
-void scalartest(uint32_t numberdistinct, uint32_t length = 1<<16, int repeat = 500) {
-    uint64_t * buf = new uint64_t[length];
+void fill_buffer(uint64_t * buf, uint32_t length, uint32_t distinct)
+{
+    srand(1);
     for(size_t i = 0; i < length; i++) {
-        buf[i] = (i % numberdistinct) * UINT64_C(0xcb9fe8c7cff9982a) + 77777 ;// made up
+        buf[i] = rand() % distinct;
+        //buf[i] = i % distinct;     // would produce streaming reads from the dictionary
     }
+}
+
+void scalartest(uint32_t distinct, uint32_t length = 1<<16, int repeat = 500) {
+    uint64_t * buf = new uint64_t[length];
+    fill_buffer(buf, length, distinct);
+
     SimpleDictCODEC scalarcodec;
     dictionary_coded_t t = scalarcodec.compress(buf, length);
+    std::cout << "Actual dict size: " << t.dictionary_size << std::endl;
     uint64_t * newbuf = new uint64_t[length];
     BEST_TIME(scalarcodec.uncompress(t,newbuf), length, repeat, length);
+    for(size_t i = 0; i < length; i++) {
+        assert(buf[i] == newbuf[i]);
+    }
+    delete[] newbuf;
+    delete[] buf;
+}
+
+#ifdef __AVX2__
+void mediumtest(uint32_t distinct, uint32_t length = 1<<16, int repeat = 500) {
+    uint64_t * buf = new uint64_t[length];
+    fill_buffer(buf, length, distinct);
+
+    AVXDictCODEC codec;
+    dictionary_coded_t t (codec.compress(buf, length) );
+    uint64_t * newbuf = new uint64_t[length];
+    BEST_TIME(codec.uncompress(t,newbuf), length, repeat, length);
     for(size_t i = 0; i < length; i++) {
         assert(buf[i] == newbuf[i]);
     }
@@ -27,9 +57,8 @@ void scalartest(uint32_t numberdistinct, uint32_t length = 1<<16, int repeat = 5
 
 void fasttest(uint32_t distinct, uint32_t length = 1<<16, int repeat = 500) {
     uint64_t * buf = new uint64_t[length];
-    for(size_t i = 0; i < length; i++) {
-        buf[i] = (i % distinct) * UINT64_C(0xcb9fe8c7cff9982a) + 77777 ;// made up
-    }
+    fill_buffer(buf, length, distinct);
+
     AVXDictCODEC codec;
     dictionary_coded_t t (codec.compress(buf, length) );
     uint64_t * newbuf = new uint64_t[length];
@@ -40,15 +69,20 @@ void fasttest(uint32_t distinct, uint32_t length = 1<<16, int repeat = 500) {
     delete[] newbuf;
     delete[] buf;
 }
-
+#endif
 
 int main() {
     printf("For this benchmark, use a recent (Skylake) Intel processor for best results.\n");
     tellmeall();
-    for(uint32_t distinct = 2; distinct < 65536; distinct *=2) {
+    uint32_t length = 1<<23;    // larger than L3 cache
+    int repeat = 5;
+    for(uint32_t distinct = 2; distinct <= (1<<20); distinct *=2) {
         std::cout << "testing with dictionary of size " << distinct << std::endl;
-        scalartest(distinct);
-        fasttest(distinct);
+        scalartest(distinct, length, repeat);
+#ifdef __AVX2__
+        mediumtest(distinct, length, repeat);
+        fasttest(distinct, length, repeat);
+#endif
         std::cout<<std::endl;
     }
     return 0;


### PR DESCRIPTION
The most important change is to prevent the dictionary indexes from being a monotonic sequence. Without it, the results are pretty much independent of the dictionary size.

I also increased the buffer size to beyond the L3 cache, it seems to make a small difference and it would be more in line with real-world uses.
